### PR TITLE
Add support for reading config from stdin and writing to stdout

### DIFF
--- a/lib/completely/commands/base.rb
+++ b/lib/completely/commands/base.rb
@@ -36,7 +36,7 @@ module Completely
 
       def completions
         @completions ||= if config_path == '-'
-          raise Error, "Nothing is piped on stdin" if $stdin.tty?
+          raise Error, 'Nothing is piped on stdin' if $stdin.tty?
 
           Completions.read $stdin, function_name: args['--function']
         else

--- a/lib/completely/commands/base.rb
+++ b/lib/completely/commands/base.rb
@@ -35,7 +35,13 @@ module Completely
       end
 
       def completions
-        @completions ||= Completions.load(config_path, function_name: args['--function'])
+        @completions ||= if config_path == '-'
+          raise Error, "Nothing is piped on stdin" if $stdin.tty?
+
+          Completions.read $stdin, function_name: args['--function']
+        else
+          Completions.load config_path, function_name: args['--function']
+        end
       end
 
       def config_path
@@ -43,7 +49,11 @@ module Completely
       end
 
       def output_path
-        @output_path ||= args['OUTPUT_PATH'] || ENV['COMPLETELY_OUTPUT_PATH'] || "#{config_basename}.bash"
+        @output_path ||= args['OUTPUT_PATH'] || ENV['COMPLETELY_OUTPUT_PATH'] || stdout || "#{config_basename}.bash"
+      end
+
+      def stdout
+        @stdout ||= config_path == '-' ? '-' : nil
       end
 
       def config_basename

--- a/lib/completely/commands/generate.rb
+++ b/lib/completely/commands/generate.rb
@@ -3,7 +3,7 @@ require 'completely/commands/base'
 module Completely
   module Commands
     class Generate < Base
-      help 'Generate the bash completion script to a file'
+      help 'Generate the bash completion script'
 
       usage 'completely generate [CONFIG_PATH OUTPUT_PATH --function NAME --wrap NAME]'
       usage 'completely generate (-h|--help)'
@@ -12,10 +12,19 @@ module Completely
       option '-w --wrap NAME', 'Wrap the completion script inside a function that echos the ' \
         'script. This is useful if you wish to embed it directly in your script.'
 
-      param_config_path
+      param 'CONFIG_PATH', <<~USAGE
+        Path to the YAML configuration file [default: completely.yaml].
+        Use '-' to read from stdin.
+        
+        Can also be set by an environment variable.
+      USAGE
+
       param 'OUTPUT_PATH', <<~USAGE
         Path to the output bash script.
-        When not provided, the name of the input file will be used with a .bash extension.
+        Use '-' for stdout.
+        
+        When not provided, the name of the input file will be used with a .bash extension, unless the input is stdin - in this case the default will be to output to stdout.
+        
         Can also be set by an environment variable.
       USAGE
 
@@ -26,8 +35,12 @@ module Completely
       def run
         wrap = args['--wrap']
         output = wrap ? wrapper_function(wrap) : script
-        File.write output_path, output
-        say "Saved m`#{output_path}`"
+        if output_path == '-'
+          puts output
+        else
+          File.write output_path, output
+          say "Saved m`#{output_path}`"
+        end
         syntax_warning unless completions.valid?
       end
 

--- a/lib/completely/commands/generate.rb
+++ b/lib/completely/commands/generate.rb
@@ -15,16 +15,16 @@ module Completely
       param 'CONFIG_PATH', <<~USAGE
         Path to the YAML configuration file [default: completely.yaml].
         Use '-' to read from stdin.
-        
+
         Can also be set by an environment variable.
       USAGE
 
       param 'OUTPUT_PATH', <<~USAGE
         Path to the output bash script.
         Use '-' for stdout.
-        
+
         When not provided, the name of the input file will be used with a .bash extension, unless the input is stdin - in this case the default will be to output to stdout.
-        
+
         Can also be set by an environment variable.
       USAGE
 

--- a/lib/completely/commands/generate.rb
+++ b/lib/completely/commands/generate.rb
@@ -3,7 +3,7 @@ require 'completely/commands/base'
 module Completely
   module Commands
     class Generate < Base
-      help 'Generate the bash completion script'
+      help 'Generate the bash completion script to file or stdout'
 
       usage 'completely generate [CONFIG_PATH OUTPUT_PATH --function NAME --wrap NAME]'
       usage 'completely generate (-h|--help)'

--- a/lib/completely/commands/install.rb
+++ b/lib/completely/commands/install.rb
@@ -35,11 +35,11 @@ module Completely
     private
 
       def installer
-        Installer.new program: args['PROGRAM'], script_path: script_path
+        @installer ||= Installer.new(program: args['PROGRAM'], script_path: script_path)
       end
 
       def script_path
-        args['SCRIPT_PATH'] || 'completely.bash'
+        @script_path ||= args['SCRIPT_PATH'] || 'completely.bash'
       end
     end
   end

--- a/lib/completely/commands/preview.rb
+++ b/lib/completely/commands/preview.rb
@@ -3,7 +3,7 @@ require 'completely/commands/base'
 module Completely
   module Commands
     class Preview < Base
-      help 'Generate the bash completion script to STDOUT'
+      help 'Generate the bash completion script to stdout'
 
       usage 'completely preview [CONFIG_PATH --function NAME]'
       usage 'completely preview (-h|--help)'

--- a/lib/completely/completions.rb
+++ b/lib/completely/completions.rb
@@ -29,7 +29,7 @@ module Completely
     end
 
     def valid?
-      pattern_prefixes.uniq.count == 1
+      pattern_prefixes.uniq.one?
     end
 
     def script

--- a/lib/completely/completions.rb
+++ b/lib/completely/completions.rb
@@ -6,9 +6,12 @@ module Completely
     attr_reader :config
 
     class << self
-      def load(config_path, function_name: nil)
-        config = Config.load config_path
-        new config, function_name: function_name
+      def load(path, function_name: nil)
+        new Config.load(path), function_name: function_name
+      end
+
+      def read(io, function_name: nil)
+        new Config.read(io), function_name: function_name
       end
     end
 

--- a/lib/completely/config.rb
+++ b/lib/completely/config.rb
@@ -3,17 +3,14 @@ module Completely
     attr_reader :config, :options
 
     class << self
-      def load(config_path)
-        begin
-          config = YAML.load_file config_path, aliases: true
-        rescue ArgumentError
-          # :nocov:
-          config = YAML.load_file config_path
-          # :nocov:
-        end
-
-        new config
+      def parse(str)
+        new YAML.load(str, aliases: true)
+      rescue Psych::Exception => e
+        raise ParseError, "Invalid YAML: #{e.message}"
       end
+
+      def load(path) = parse(File.read(path))
+      def read(io) = parse(io.read)
     end
 
     def initialize(config)

--- a/lib/completely/exceptions.rb
+++ b/lib/completely/exceptions.rb
@@ -1,4 +1,5 @@
 module Completely
   class Error < StandardError; end
   class InstallError < Error; end
+  class ParseError < Error; end
 end

--- a/lib/completely/installer.rb
+++ b/lib/completely/installer.rb
@@ -73,15 +73,13 @@ module Completely
     end
 
     def completions_path
-      @completions_path ||= completions_path!
-    end
+      @completions_path ||= begin
+        target_directories.each do |target|
+          return target if Dir.exist? target
+        end
 
-    def completions_path!
-      target_directories.each do |target|
-        return target if Dir.exist? target
+        nil
       end
-
-      nil
     end
   end
 end

--- a/spec/approvals/cli/commands
+++ b/spec/approvals/cli/commands
@@ -3,7 +3,7 @@ Completely - Bash Completions Generator
 Commands:
   init       Create a new sample YAML configuration file
   preview    Generate the bash completion script to STDOUT
-  generate   Generate the bash completion script to a file
+  generate   Generate the bash completion script
   test       Test completions
   install    Install a bash completion script
   uninstall  Uninstall a bash completion script

--- a/spec/approvals/cli/commands
+++ b/spec/approvals/cli/commands
@@ -2,8 +2,8 @@ Completely - Bash Completions Generator
 
 Commands:
   init       Create a new sample YAML configuration file
-  preview    Generate the bash completion script to STDOUT
-  generate   Generate the bash completion script
+  preview    Generate the bash completion script to stdout
+  generate   Generate the bash completion script to file or stdout
   test       Test completions
   install    Install a bash completion script
   uninstall  Uninstall a bash completion script

--- a/spec/approvals/cli/generate/custom-path-stdin
+++ b/spec/approvals/cli/generate/custom-path-stdin
@@ -1,0 +1,1 @@
+Saved spec/tmp/stdin-to-file.bash

--- a/spec/approvals/cli/generate/help
+++ b/spec/approvals/cli/generate/help
@@ -1,4 +1,4 @@
-Generate the bash completion script
+Generate the bash completion script to file or stdout
 
 Usage:
   completely generate [CONFIG_PATH OUTPUT_PATH --function NAME --wrap NAME]

--- a/spec/approvals/cli/generate/help
+++ b/spec/approvals/cli/generate/help
@@ -1,4 +1,4 @@
-Generate the bash completion script to a file
+Generate the bash completion script
 
 Usage:
   completely generate [CONFIG_PATH OUTPUT_PATH --function NAME --wrap NAME]
@@ -18,12 +18,18 @@ Options:
 Parameters:
   CONFIG_PATH
     Path to the YAML configuration file [default: completely.yaml].
+    Use '-' to read from stdin.
+    
     Can also be set by an environment variable.
 
   OUTPUT_PATH
     Path to the output bash script.
+    Use '-' for stdout.
+    
     When not provided, the name of the input file will be used with a .bash
-    extension.
+    extension, unless the input is stdin - in this case the default will be to
+    output to stdout.
+    
     Can also be set by an environment variable.
 
 Environment Variables:

--- a/spec/approvals/cli/install/help
+++ b/spec/approvals/cli/install/help
@@ -25,3 +25,4 @@ Parameters:
 
   SCRIPT_PATH
     Path to the source bash script [default: completely.bash].
+    Use '-' to provide the script via stdin.

--- a/spec/approvals/cli/install/stdin-dry
+++ b/spec/approvals/cli/install/stdin-dry
@@ -1,0 +1,1 @@
+sudo cp <tmpfile-path> /usr/share/bash-completion/completions/completely-test

--- a/spec/approvals/cli/install/stdin-install
+++ b/spec/approvals/cli/install/stdin-install
@@ -1,0 +1,2 @@
+Saved some-target-path
+You may need to restart your session to test it

--- a/spec/approvals/cli/preview/help
+++ b/spec/approvals/cli/preview/help
@@ -1,4 +1,4 @@
-Generate the bash completion script to STDOUT
+Generate the bash completion script to stdout
 
 Usage:
   completely preview [CONFIG_PATH --function NAME]

--- a/spec/completely/commands/generate_spec.rb
+++ b/spec/completely/commands/generate_spec.rb
@@ -1,8 +1,14 @@
 describe Commands::Generate do
   subject { described_class.new }
 
-  before { system 'cp lib/completely/templates/sample.yaml completely.yaml' }
-  after  { system 'rm -f completely.yaml' }
+  before do
+    reset_tmp_dir
+    system 'cp lib/completely/templates/sample.yaml completely.yaml'
+  end
+
+  after do
+    system 'rm -f completely.yaml'
+  end
 
   context 'with --help' do
     it 'shows long usage' do
@@ -78,6 +84,28 @@ describe Commands::Generate do
       expect { subject.execute %w[generate completely.yaml spec/tmp/out.bash] }
         .to output_approval('cli/generate/custom-out-path')
       expect(File.read 'spec/tmp/out.bash').to match_approval('cli/generated-script')
+    end
+  end
+
+  context 'with stdin and stdout' do
+    it 'reads config from stdin and writes to stdout' do
+      allow($stdin).to receive(:tty?).and_return false
+      allow($stdin).to receive(:read).and_return File.read('completely.yaml')
+
+      expect { subject.execute %w[generate -] }
+        .to output_approval('cli/generated-script')
+    end
+  end
+
+  context 'with stdin and output path' do
+    let(:outfile) { 'spec/tmp/stdin-to-file.bash' }
+
+    it 'reads config from stdin and writes to file' do
+      allow($stdin).to receive(:tty?).and_return false
+      allow($stdin).to receive(:read).and_return File.read('completely.yaml')
+
+      expect { subject.execute %W[generate - #{outfile}] }.to output_approval('cli/generate/custom-path-stdin')
+      expect(File.read outfile).to match_approval('cli/generated-script')
     end
   end
 

--- a/spec/completely/commands/generate_spec.rb
+++ b/spec/completely/commands/generate_spec.rb
@@ -89,8 +89,7 @@ describe Commands::Generate do
 
   context 'with stdin and stdout' do
     it 'reads config from stdin and writes to stdout' do
-      allow($stdin).to receive(:tty?).and_return false
-      allow($stdin).to receive(:read).and_return File.read('completely.yaml')
+      allow($stdin).to receive_messages(tty?: false, read: File.read('completely.yaml'))
 
       expect { subject.execute %w[generate -] }
         .to output_approval('cli/generated-script')
@@ -101,8 +100,7 @@ describe Commands::Generate do
     let(:outfile) { 'spec/tmp/stdin-to-file.bash' }
 
     it 'reads config from stdin and writes to file' do
-      allow($stdin).to receive(:tty?).and_return false
-      allow($stdin).to receive(:read).and_return File.read('completely.yaml')
+      allow($stdin).to receive_messages(tty?: false, read: File.read('completely.yaml'))
 
       expect { subject.execute %W[generate - #{outfile}] }.to output_approval('cli/generate/custom-path-stdin')
       expect(File.read outfile).to match_approval('cli/generated-script')

--- a/spec/completely/commands/install_spec.rb
+++ b/spec/completely/commands/install_spec.rb
@@ -34,6 +34,20 @@ describe Commands::Install do
     end
   end
 
+  context 'with PROGRAM - (stdin)' do
+    it 'invokes the Installer using a temp file' do
+      allow(subject).to receive(:installer).and_return(mock_installer)
+      allow($stdin).to receive_messages(tty?: false, read: 'dummy data')
+
+      expect(mock_installer).to receive(:install)
+
+      expect { subject.execute %w[install completely-test -] }
+        .to output_approval('cli/install/stdin-install')
+
+      expect(File.read subject.tempfile.path).to eq 'dummy data'
+    end
+  end
+
   context 'with PROGRAM --dry' do
     it 'shows the command and does not install anything' do
       expect(mock_installer).not_to receive(:install)
@@ -42,6 +56,29 @@ describe Commands::Install do
         .to output_approval('cli/install/dry')
     end
   end
+
+  context 'with PROGRAM - --dry (stdin)' do
+    it 'shows the command and does not install anything' do
+      allow($stdin).to receive_messages(tty?: false, read: 'dummy data')
+
+      expect(mock_installer).not_to receive(:install)
+
+      expect { subject.execute %w[install completely-test - --dry] }
+        .to output_approval('cli/install/stdin-dry')
+        .except(/[^\s]*stdin-completely-[^\s]*/, '<tmpfile-path>')
+    end
+
+    context 'when stdin is empty' do
+      it 'raises InstallError' do
+        allow($stdin).to receive_messages(tty?: true, read: nil)
+        expect(mock_installer).not_to receive(:install)
+
+        expect { subject.execute %w[install completely-test - --dry] }
+          .to raise_error(InstallError, 'Nothing is piped on stdin')
+      end
+    end
+  end
+
 
   context 'when the installer fails' do
     it 'raises an error' do

--- a/spec/completely/completions_spec.rb
+++ b/spec/completely/completions_spec.rb
@@ -4,6 +4,13 @@ describe Completions do
   let(:path) { "spec/fixtures/#{file}.yaml" }
   let(:file) { 'basic' }
 
+  describe '::read' do
+    it 'reads from io' do
+      io = double :io, read: "cli: [--help, --version]"
+      expect(described_class.read(io).config.config).to eq({ 'cli' => %w[--help --version] })
+    end
+  end
+
   describe '#valid?' do
     context 'when all patterns start with the same word' do
       it 'returns true' do

--- a/spec/completely/config_spec.rb
+++ b/spec/completely/config_spec.rb
@@ -3,6 +3,27 @@ describe Config do
 
   let(:path) { "spec/fixtures/#{file}.yaml" }
   let(:file) { 'nested' }
+  let(:config_string) { "cli: [--help, --version]" }
+  let(:config_hash) { { 'cli' => %w[--help --version] } }
+
+  describe '::parse' do
+    it 'loads config from string' do
+      expect(described_class.parse(config_string).config).to eq config_hash
+    end
+
+    context 'when the string is not a valid YAML' do
+      it 'raises ParseError' do
+        expect { described_class.parse("not: a: yaml") }.to raise_error(Completely::ParseError)
+      end
+    end
+  end
+
+  describe '::read' do
+    it 'loads config from io' do
+      io = double :io, read: config_string
+      expect(described_class.read(io).config).to eq config_hash
+    end
+  end
 
   describe '#flat_config' do
     it 'returns a flat pattern => completions hash' do

--- a/spec/completely/installer_spec.rb
+++ b/spec/completely/installer_spec.rb
@@ -25,6 +25,16 @@ describe Installer do
       expect(subject.target_path)
         .to eq '/usr/share/bash-completion/completions/completely-test'
     end
+
+    # This method will not be called if there is no completions path
+    # The test is here to cover the nil fallback
+    context 'when no paths found' do
+      it 'returns nil as the base path' do
+        allow(subject).to receive(:target_directories).and_return([])
+
+        expect(subject.target_path).to eq '/completely-test'
+      end
+    end
   end
 
   describe '#install_command' do


### PR DESCRIPTION
cc #83 

This PR updates the `completely generate` command so it can now accept `-` as a config path argument (and optionally, as output path). These represent stdin/stdout.

In addition, the `completely install` command can now read from stdin, using `-`.



